### PR TITLE
Benchmarks, a few minor optimizations, 5% perf gain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,11 @@ keywords = ["rectangle", "rect", "packer", "sprite", "atlas"]
 categories = ["algorithms", "game-development", "graphics"]
 
 [dependencies]
+
+[dev-dependencies]
+criterion = "0.5"
+image = { version = "0.24.7", default-features = false, features = ["png"] }
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crunch"
 version = "0.5.3"
 authors = ["Chevy Ray Johnston <happytrash@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A packer for cramming lots of rectangles into a larger one, designed primarily with sprite packing in mind."
 readme = "README.md"
 repository = "https://github.com/ChevyRay/crunch-rs"

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ fn main() {
     // Our items to pack. The user-data here are chars,
     // but could be any copyable type
     let items = [
-        Item::new('A', 2, 9, Rotation::Allowed),
-        Item::new('B', 3, 8, Rotation::Allowed),
-        Item::new('C', 4, 7, Rotation::Allowed),
-        Item::new('D', 5, 6, Rotation::Allowed),
-        Item::new('E', 6, 5, Rotation::Allowed),
-        Item::new('F', 7, 4, Rotation::Allowed),
-        Item::new('G', 8, 3, Rotation::Allowed),
-        Item::new('H', 9, 2, Rotation::Allowed),
+        Item::new(&'A', 2, 9, Rotation::Allowed),
+        Item::new(&'B', 3, 8, Rotation::Allowed),
+        Item::new(&'C', 4, 7, Rotation::Allowed),
+        Item::new(&'D', 5, 6, Rotation::Allowed),
+        Item::new(&'E', 6, 5, Rotation::Allowed),
+        Item::new(&'F', 7, 4, Rotation::Allowed),
+        Item::new(&'G', 8, 3, Rotation::Allowed),
+        Item::new(&'H', 9, 2, Rotation::Allowed),
     ];
 
     // Now we can try to pack all the items into this container

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ fn main() {
     // Our items to pack. The user-data here are chars,
     // but could be any copyable type
     let items = [
-        Item::new(&'A', 2, 9, Rotation::Allowed),
-        Item::new(&'B', 3, 8, Rotation::Allowed),
-        Item::new(&'C', 4, 7, Rotation::Allowed),
-        Item::new(&'D', 5, 6, Rotation::Allowed),
-        Item::new(&'E', 6, 5, Rotation::Allowed),
-        Item::new(&'F', 7, 4, Rotation::Allowed),
-        Item::new(&'G', 8, 3, Rotation::Allowed),
-        Item::new(&'H', 9, 2, Rotation::Allowed),
+        Item::new('A', 2, 9, Rotation::Allowed),
+        Item::new('B', 3, 8, Rotation::Allowed),
+        Item::new('C', 4, 7, Rotation::Allowed),
+        Item::new('D', 5, 6, Rotation::Allowed),
+        Item::new('E', 6, 5, Rotation::Allowed),
+        Item::new('F', 7, 4, Rotation::Allowed),
+        Item::new('G', 8, 3, Rotation::Allowed),
+        Item::new('H', 9, 2, Rotation::Allowed),
     ];
 
     // Now we can try to pack all the items into this container

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,27 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use crunch::{Item, Rotation};
+use std::path::PathBuf;
+
+pub fn pack_images(c: &mut Criterion) {
+    // Get image sizes, ignoring the actual images
+    let items: Vec<_> = std::fs::read_dir(PathBuf::from("examples/pack_images/img"))
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.unwrap().path();
+            if path.is_file() {
+                let img = image::open(path).unwrap().to_rgba8();
+                let (w, h) = (img.width() as usize, img.height() as usize);
+                Some(Item::new(0_u8, w, h, Rotation::None))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    c.bench_function("pack all images", |b| {
+        b.iter(|| crunch::pack_into_po2(1024, black_box(items.clone())))
+    });
+}
+
+criterion_group!(benches, pack_images);
+criterion_main!(benches);

--- a/examples/pack_images/Cargo.toml
+++ b/examples/pack_images/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pack_images"
 version = "0.1.0"
 authors = ["Chevy Ray Johnston <happytrash@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 crunch = { path = "../.." }

--- a/examples/pack_images/src/main.rs
+++ b/examples/pack_images/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
     println!("loading images...");
 
     // Load all the files into RGBA images
-    let items: [Item<RgbaImage>; 26] = [
+    let items = [
         "img/img1.png",
         "img/img2.png",
         "img/img3.png",
@@ -43,27 +43,23 @@ fn main() {
     println!("packing {} images...", items.len());
 
     // Try packing all the rectangles
-    match crunch::pack_into_po2(1024, items) {
-        Ok(PackedItems { w, h, items }) => {
-            println!("images packed into ({w} x {h}) rect");
+    let PackedItems { w, h, items } =
+        crunch::pack_into_po2(1024, items).expect("failed to pack images");
 
-            // Create a target atlas image to draw the packed images onto
-            let mut atlas = RgbaImage::from_pixel(w as u32, h as u32, Rgba([0, 0, 0, 0]));
+    println!("images packed into ({w} x {h}) rect");
 
-            // Copy all the packed images onto the target atlas
-            for PackedItem { data, rect } in items {
-                atlas
-                    .copy_from(&data, rect.x as u32, rect.y as u32)
-                    .unwrap();
-            }
+    // Create a target atlas image to draw the packed images onto
+    let mut atlas = RgbaImage::from_pixel(w as u32, h as u32, Rgba([0, 0, 0, 0]));
 
-            println!("exporting `packed.png`...");
-
-            // Export the packed atlas
-            atlas.save("packed.png").unwrap();
-        }
-        Err(_) => {
-            panic!("failed to pack images");
-        }
+    // Copy all the packed images onto the target atlas
+    for PackedItem { data, rect } in items {
+        atlas
+            .copy_from(&data, rect.x as u32, rect.y as u32)
+            .unwrap();
     }
+
+    println!("exporting `packed.png`...");
+
+    // Export the packed atlas
+    atlas.save("packed.png").unwrap();
 }

--- a/examples/pack_images/src/main.rs
+++ b/examples/pack_images/src/main.rs
@@ -1,4 +1,3 @@
-extern crate image;
 use crunch::{Item, PackedItem, PackedItems, Rotation};
 use image::{GenericImage, Rgba, RgbaImage};
 

--- a/examples/pack_images/src/main.rs
+++ b/examples/pack_images/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
     .map(|file| {
         let img = image::open(file).unwrap().to_rgba8();
         let (w, h) = (img.width() as usize, img.height() as usize);
-        println!("\tloaded: `{}` ({} x {})", file, w, h);
+        println!("\tloaded: `{file}` ({w} x {h})");
         Item::new(img, w, h, Rotation::None)
     });
 
@@ -46,7 +46,7 @@ fn main() {
     // Try packing all the rectangles
     match crunch::pack_into_po2(1024, items) {
         Ok(PackedItems { w, h, items }) => {
-            println!("images packed into ({} x {}) rect", w, h);
+            println!("images packed into ({w} x {h}) rect");
 
             // Create a target atlas image to draw the packed images onto
             let mut atlas = RgbaImage::from_pixel(w as u32, h as u32, Rgba([0, 0, 0, 0]));

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,7 +1,7 @@
 use crate::Rect;
 
 /// Rotation setting for packing rectangles.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Rotation {
     /// The item may not be rotated.
     None,
@@ -11,7 +11,6 @@ pub enum Rotation {
 }
 
 /// An item to be packed by `Packer`.
-#[derive(Clone)]
 pub struct Item<T> {
     /// Data associated with the item (for example, an ID or a
     /// reference to an image).
@@ -49,7 +48,7 @@ impl<T> Item<T> {
 }
 
 /// A container of packed items.
-pub struct PackedItems<T> {
+pub struct PackedItems<'a, T: 'a> {
     /// The width of the container.
     pub w: usize,
 
@@ -57,13 +56,13 @@ pub struct PackedItems<T> {
     pub h: usize,
 
     /// The items packed into the container.
-    pub items: Vec<PackedItem<T>>,
+    pub items: Vec<PackedItem<'a, T>>,
 }
 
 /// An item that has been packed into a container.
-pub struct PackedItem<T> {
+pub struct PackedItem<'a, T: 'a> {
     /// The data associated with the item.
-    pub data: T,
+    pub data: &'a T,
 
     /// The position where the item was packed.
     ///

--- a/src/item.rs
+++ b/src/item.rs
@@ -11,6 +11,7 @@ pub enum Rotation {
 }
 
 /// An item to be packed by `Packer`.
+#[derive(Clone)]
 pub struct Item<T> {
     /// Data associated with the item (for example, an ID or a
     /// reference to an image).
@@ -48,7 +49,7 @@ impl<T> Item<T> {
 }
 
 /// A container of packed items.
-pub struct PackedItems<'a, T: 'a> {
+pub struct PackedItems<T> {
     /// The width of the container.
     pub w: usize,
 
@@ -56,13 +57,13 @@ pub struct PackedItems<'a, T: 'a> {
     pub h: usize,
 
     /// The items packed into the container.
-    pub items: Vec<PackedItem<'a, T>>,
+    pub items: Vec<PackedItem<T>>,
 }
 
 /// An item that has been packed into a container.
-pub struct PackedItem<'a, T: 'a> {
+pub struct PackedItem<T> {
     /// The data associated with the item.
-    pub data: &'a T,
+    pub data: T,
 
     /// The position where the item was packed.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,14 @@ let container = Rect::of_size(15, 15);
 // Our items to pack. The user-data here are chars,
 // but could be any copyable type
 let items = [
-    Item::new(&'A', 2, 9, Rotation::Allowed),
-    Item::new(&'B', 3, 8, Rotation::Allowed),
-    Item::new(&'C', 4, 7, Rotation::Allowed),
-    Item::new(&'D', 5, 6, Rotation::Allowed),
-    Item::new(&'E', 6, 5, Rotation::Allowed),
-    Item::new(&'F', 7, 4, Rotation::Allowed),
-    Item::new(&'G', 8, 3, Rotation::Allowed),
-    Item::new(&'H', 9, 2, Rotation::Allowed),
+    Item::new('A', 2, 9, Rotation::Allowed),
+    Item::new('B', 3, 8, Rotation::Allowed),
+    Item::new('C', 4, 7, Rotation::Allowed),
+    Item::new('D', 5, 6, Rotation::Allowed),
+    Item::new('E', 6, 5, Rotation::Allowed),
+    Item::new('F', 7, 4, Rotation::Allowed),
+    Item::new('G', 8, 3, Rotation::Allowed),
+    Item::new('H', 9, 2, Rotation::Allowed),
 ];
 
 // Now we can try to pack all the items into this container
@@ -46,7 +46,7 @@ let mut data : Vec<char> =
 for item in &packed {
     for x in item.rect.x..item.rect.right() {
         for y in item.rect.y..item.rect.bottom() {
-            data[y * (container.w + 1) + x] = *item.data;
+            data[y * (container.w + 1) + x] = item.data;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,67 +12,65 @@ Supports 90° rotation on a per-item basis.
 use crunch::{pack, Rect, Item, Rotation};
 use std::iter::*;
 
-fn main() {
-    // The 15x15 container we'll be packing our items into
-    let container = Rect::of_size(15, 15);
+// The 15x15 container we'll be packing our items into
+let container = Rect::of_size(15, 15);
 
-    // Our items to pack. The user-data here are chars,
-    // but could be any copyable type
-    let items = [
-        Item::new(&'A', 2, 9, Rotation::Allowed),
-        Item::new(&'B', 3, 8, Rotation::Allowed),
-        Item::new(&'C', 4, 7, Rotation::Allowed),
-        Item::new(&'D', 5, 6, Rotation::Allowed),
-        Item::new(&'E', 6, 5, Rotation::Allowed),
-        Item::new(&'F', 7, 4, Rotation::Allowed),
-        Item::new(&'G', 8, 3, Rotation::Allowed),
-        Item::new(&'H', 9, 2, Rotation::Allowed),
-    ];
+// Our items to pack. The user-data here are chars,
+// but could be any copyable type
+let items = [
+    Item::new(&'A', 2, 9, Rotation::Allowed),
+    Item::new(&'B', 3, 8, Rotation::Allowed),
+    Item::new(&'C', 4, 7, Rotation::Allowed),
+    Item::new(&'D', 5, 6, Rotation::Allowed),
+    Item::new(&'E', 6, 5, Rotation::Allowed),
+    Item::new(&'F', 7, 4, Rotation::Allowed),
+    Item::new(&'G', 8, 3, Rotation::Allowed),
+    Item::new(&'H', 9, 2, Rotation::Allowed),
+];
 
-    // Now we can try to pack all the items into this container
-    let result = pack(container, items);
-    let packed = match result {
-        Ok(all_packed) => all_packed,
-        Err(some_packed) => some_packed,
-    };
+// Now we can try to pack all the items into this container
+let result = pack(container, items);
+let packed = match result {
+    Ok(all_packed) => all_packed,
+    Err(some_packed) => some_packed,
+};
 
-    // To display the results, let's create a 15x15 grid of '.' characters
-    let mut data : Vec<char> =
-        repeat(repeat('.').take(container.w).chain(once('\n')))
-        .take(container.h)
-        .flatten()
-        .collect();
+// To display the results, let's create a 15x15 grid of '.' characters
+let mut data : Vec<char> =
+    repeat(repeat('.').take(container.w).chain(once('\n')))
+    .take(container.h)
+    .flatten()
+    .collect();
 
-    // We can iterate through each (rect, data) pair that was packed
-    for item in &packed {
-        for x in item.rect.x..item.rect.right() {
-            for y in item.rect.y..item.rect.bottom() {
-                data[y * (container.w + 1) + x] = *item.data;
-            }
+// We can iterate through each (rect, data) pair that was packed
+for item in &packed {
+    for x in item.rect.x..item.rect.right() {
+        for y in item.rect.y..item.rect.bottom() {
+            data[y * (container.w + 1) + x] = *item.data;
         }
     }
-
-    // The items packed very efficiently, using 90% of the 15x15
-    // container's space. You'll notice that some ('H', for example)
-    // were able to rotate to fit.
-    println!("{}", String::from_iter(data));
-
-    // EEEEEEDDDDDDBBB
-    // EEEEEEDDDDDDBBB
-    // EEEEEEDDDDDDBBB
-    // EEEEEEDDDDDDBBB
-    // EEEEEEDDDDDDBBB
-    // FFFFCCCCHHAABBB
-    // FFFFCCCCHHAABBB
-    // FFFFCCCCHHAABBB
-    // FFFFCCCCHHAA...
-    // FFFFCCCCHHAA...
-    // FFFFCCCCHHAA...
-    // FFFFCCCCHHAA...
-    // GGGGGGGGHHAA...
-    // GGGGGGGGHHAA...
-    // GGGGGGGG.......
 }
+
+// The items packed very efficiently, using 90% of the 15x15
+// container's space. You'll notice that some ('H', for example)
+// were able to rotate to fit.
+println!("{}", String::from_iter(data));
+
+// EEEEEEDDDDDDBBB
+// EEEEEEDDDDDDBBB
+// EEEEEEDDDDDDBBB
+// EEEEEEDDDDDDBBB
+// EEEEEEDDDDDDBBB
+// FFFFCCCCHHAABBB
+// FFFFCCCCHHAABBB
+// FFFFCCCCHHAABBB
+// FFFFCCCCHHAA...
+// FFFFCCCCHHAA...
+// FFFFCCCCHHAA...
+// FFFFCCCCHHAA...
+// GGGGGGGGHHAA...
+// GGGGGGGGHHAA...
+// GGGGGGGG.......
 ```
 
 If you are packing textures, you can also use the `pack_into_po2()` helper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,14 @@ fn main() {
     // Our items to pack. The user-data here are chars,
     // but could be any copyable type
     let items = [
-        Item::new('A', 2, 9, Rotation::Allowed),
-        Item::new('B', 3, 8, Rotation::Allowed),
-        Item::new('C', 4, 7, Rotation::Allowed),
-        Item::new('D', 5, 6, Rotation::Allowed),
-        Item::new('E', 6, 5, Rotation::Allowed),
-        Item::new('F', 7, 4, Rotation::Allowed),
-        Item::new('G', 8, 3, Rotation::Allowed),
-        Item::new('H', 9, 2, Rotation::Allowed),
+        Item::new(&'A', 2, 9, Rotation::Allowed),
+        Item::new(&'B', 3, 8, Rotation::Allowed),
+        Item::new(&'C', 4, 7, Rotation::Allowed),
+        Item::new(&'D', 5, 6, Rotation::Allowed),
+        Item::new(&'E', 6, 5, Rotation::Allowed),
+        Item::new(&'F', 7, 4, Rotation::Allowed),
+        Item::new(&'G', 8, 3, Rotation::Allowed),
+        Item::new(&'H', 9, 2, Rotation::Allowed),
     ];
 
     // Now we can try to pack all the items into this container
@@ -47,7 +47,7 @@ fn main() {
     for item in &packed {
         for x in item.rect.x..item.rect.right() {
             for y in item.rect.y..item.rect.bottom() {
-                data[y * (container.w + 1) + x] = item.data;
+                data[y * (container.w + 1) + x] = *item.data;
             }
         }
     }

--- a/src/packer.rs
+++ b/src/packer.rs
@@ -10,7 +10,7 @@ use std::iter::*;
 /// Shorthand for:
 /// ```
 /// # use crunch::{Rect, Packer, Item};
-/// # let items: Vec<Item<&char>> = Vec::new();
+/// # let items: Vec<Item<char>> = Vec::new();
 /// # let into_rect = Rect::of_size(1024, 1024);
 /// let mut packer = Packer::with_items(items);
 /// packer.pack(into_rect);
@@ -21,14 +21,14 @@ use std::iter::*;
 /// # use crunch::{Rect, Item, Rotation, pack, PackedItems};
 /// let rect = Rect::of_size(15, 15);
 /// let items = vec![
-///     Item::new(&'A', 2, 9, Rotation::Allowed),
-///     Item::new(&'B', 3, 8, Rotation::Allowed),
-///     Item::new(&'C', 4, 7, Rotation::Allowed),
-///     Item::new(&'D', 5, 6, Rotation::Allowed),
-///     Item::new(&'E', 6, 5, Rotation::Allowed),
-///     Item::new(&'F', 7, 4, Rotation::Allowed),
-///     Item::new(&'G', 8, 3, Rotation::Allowed),
-///     Item::new(&'H', 9, 2, Rotation::Allowed),
+///     Item::new('A', 2, 9, Rotation::Allowed),
+///     Item::new('B', 3, 8, Rotation::Allowed),
+///     Item::new('C', 4, 7, Rotation::Allowed),
+///     Item::new('D', 5, 6, Rotation::Allowed),
+///     Item::new('E', 6, 5, Rotation::Allowed),
+///     Item::new('F', 7, 4, Rotation::Allowed),
+///     Item::new('G', 8, 3, Rotation::Allowed),
+///     Item::new('H', 9, 2, Rotation::Allowed),
 /// ];
 ///
 /// let packed = match pack(rect, items) {
@@ -72,14 +72,7 @@ pub struct Packer<T> {
     indices: Vec<usize>,
 }
 
-impl<T: Clone> Default for Packer<T> {
-    /// Default packer, equivalent to `Packer::new()`.
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<T: Clone> Packer<T> {
+impl<T> Packer<T> {
     /// Create a new, empty packer.
     pub const fn new() -> Self {
         Self {
@@ -106,7 +99,16 @@ impl<T: Clone> Packer<T> {
             indices: Vec::new(),
         }
     }
+}
 
+impl<T> Default for Packer<T> {
+    /// Default packer, equivalent to `Packer::new()`.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Clone> Packer<T> {
     pub fn clear(&mut self) -> &mut Self {
         self.items_to_pack.clear();
         self


### PR DESCRIPTION
* Add a benchmark that uses all image sizes (ignoring the image data itself)
* This change gets 5% boost in my testing
* bumps the edition to 2021
* adds a few Debug traits
* made `leaf_contains_rect` and `split_tree` not use `self` due to borrowing rules - easier to separate them. Perhaps `Nodes` could even be made into its own separate struct, as it does not need to reference anything outside of it.